### PR TITLE
Adds support for enums as id and resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ uri.to_s # => 'com.example:billing:invoice:R422342'
 InvoiceURI.build('com.example:billing:invoice:R422342') # => #<InvoiceURI 'com.example:billing:invoice:R422342'>
 InvoiceURI.build(id: 'R422342') # => #<InvoiceURI 'com.example:billing:invoice:R422342'>
 InvoiceURI.build(uri) # => #<InvoiceURI 'com.example:billing:invoice:R422342'>
+
+# `resource` and `id` supports array so that `.build` will verify every value for a given string.
+# If we also want to check the initializer we can use the "types" extension to do so:
+require 'studitemps/utils/uri/extensions/types'
+
+InvoiceURI = Studitemps::Utils::URI.build(
+  schema: 'com.example', context: 'billing', resource: 'invoice', id: %w[final past_due]
+)
+
+InvoiceURI.build('com.example:billing:invoice:pro_forma') # => Studitemps::Utils::URI::Base::InvalidURI
+InvoiceURI.new(id: 'final') # => #<InvoiceURI 'com.example:billing:invoice:final'>
+InvoiceURI.new(id: 'pro_forma') # => Dry::Types::ConstraintError
 ```
 
 ### Extensions

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ An Studitemps Utils URI references similar to a normal URI a specific resource. 
 of the time when used to reference a resource it also has a `context`, `resource`, and an `id`.
 
 Example: `com.example:billing:invoice:R422342`
-  - schema: `com.example` - Some kind of schema to make URI globally unique.
-  - context: `billing` - The context the URI (and the resource) belongs to.
-  - resource: `invoice` - The resource type.
-  - id: `R422342` - The resource id.
+
+-   schema: `com.example` - Some kind of schema to make URI globally unique.
+-   context: `billing` - The context the URI (and the resource) belongs to.
+-   resource: `invoice` - The resource type.
+-   id: `R422342` - The resource id.
 
 ### Usage
 
@@ -91,6 +92,7 @@ MyBaseURI.load('com.example:billing:invoice:R422342') # =>  #<MyBaseURI 'com.exa
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
+
 <!-- To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org). -->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ gem 'studitemps-utils'
 
 And then execute:
 
-    $ bundle
+```shell
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install studitemps-utils
+```shell
+$ gem install studitemps-utils
+```
 
 ## URI
 
@@ -33,10 +37,10 @@ An Studitemps Utils URI references similar to a normal URI a specific resource. 
 of the time when used to reference a resource it also has a `context`, `resource`, and an `id`.
 
 Example: `com.example:billing:invoice:R422342`
-- schema: `com.example` - Some kind of schema to make URI globally unique.
-- context: `billing` - The context the URI (and the resource) belongs to.
-- resource: `invoice` - The resource type.
-- id: `R422342` - The resource id.
+  - schema: `com.example` - Some kind of schema to make URI globally unique.
+  - context: `billing` - The context the URI (and the resource) belongs to.
+  - resource: `invoice` - The resource type.
+  - id: `R422342` - The resource id.
 
 ### Usage
 
@@ -91,7 +95,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/STUDITEMPS/studitemps-utils.
+Bug reports and pull requests are welcome on GitHub at <https://github.com/STUDITEMPS/studitemps-utils>.
 
 ## License
 

--- a/lib/studitemps/utils/uri.rb
+++ b/lib/studitemps/utils/uri.rb
@@ -41,8 +41,8 @@ module Studitemps
       #
       #  ExampleURI.build('com.example:billing:invoice:R422342')
       #  # => #<ExampleURI 'com.example:billing:invoice:R422342'>
-      def build(schema: nil, context: nil, resource: nil, from: Base)
-        Builder.new.call(schema: schema, context: context, resource: resource, superclass: from)
+      def build(schema: nil, context: nil, resource: nil, id: nil, from: Base)
+        Builder.new.call(schema: schema, context: context, resource: resource, id: id, superclass: from)
       end
     end
   end

--- a/lib/studitemps/utils/uri/base.rb
+++ b/lib/studitemps/utils/uri/base.rb
@@ -14,6 +14,7 @@ module Studitemps
         defines :schema
         defines :context
         defines :resource
+        defines :id
 
         # Returns string representation of URI.
         #

--- a/lib/studitemps/utils/uri/base.rb
+++ b/lib/studitemps/utils/uri/base.rb
@@ -16,6 +16,12 @@ module Studitemps
         defines :resource
         defines :id
 
+        # @!parse
+        #   # Regular expression which the string representation of the URI has to match.
+        #   #   `value` - matches the exact value
+        #   #   `enum` - matches any of the given values
+        #   REGEX = /\A(?<schema>`value`)\:(?<context>`value`)(:(?<resource>`enum`)(:(?<id>`enum`))?)?\z/
+
         # Returns string representation of URI.
         #
         # @example

--- a/lib/studitemps/utils/uri/builder.rb
+++ b/lib/studitemps/utils/uri/builder.rb
@@ -21,11 +21,11 @@ module Studitemps
         #
         # @note Use {URI.build} instead to create new URI classes
         # @api private
-        def call(schema: nil, context: nil, resource: nil, superclass: ::Studitemps::Utils::URI::Base)
+        def call(schema: nil, context: nil, resource: nil, id: nil, superclass: ::Studitemps::Utils::URI::Base)
           raise ArgumentError, 'missing schema' if superclass == ::Studitemps::Utils::URI::Base && schema.nil?
 
           klass = build_class(superclass)
-          configure_class(klass, schema, context, resource)
+          configure_class(klass, schema, context, resource, id)
           build_regex(klass)
           build_initializer(klass)
           run_extensions(klass)
@@ -38,40 +38,60 @@ module Studitemps
           Class.new(superclass)
         end
 
-        def configure_class(klass, new_schema, new_context, new_resource)
+        def configure_class(klass, new_schema, new_context, new_resource, new_id)
           klass.class_eval do
             schema new_schema if new_schema
             context new_context if new_context
             resource new_resource if new_resource
+            id new_id if new_id
           end
         end
 
-        def build_regex(klass, default: '[\w\-_]+')
-          schema = Regexp.escape(klass.schema)
-          context = klass.context ? Regexp.escape(klass.context) : default
-          resource = klass.resource ? Regexp.escape(klass.resource) : default
+        def build_regex(klass)
           regex = /\A
-            (?<schema>#{schema})\:
-            (?<context>#{context})
-            (:(?<resource>#{resource})
-            (:(?<id>.*))?)?
+            (?<schema>#{value_regex(:schema, klass)})\:
+            (?<context>#{value_regex(:context, klass)})
+            (:(?<resource>#{enum_regex(:resource, klass)})
+            (:(?<id>#{enum_regex(:id, klass, default: '.*')}))?)?
           \z/x
           klass.const_set('REGEX', regex.freeze)
         end
 
         def build_initializer(klass) # rubocop:disable Metrics/AbcSize
-          klass.class_eval do
-            include Dry::Initializer[undefined: false].define -> {
-              option :schema, proc(&:to_s), optional: false, default: -> { klass.schema }
-              option :context, proc(&:to_s), optional: true, default: -> { klass.context }
-              option :resource, proc(&:to_s), optional: true, default: -> { klass.resource }
-              option :id, proc(&:to_s), optional: true
-            }
-          end
+          klass.extend Dry::Initializer[undefined: false]
+
+          klass.option :schema, type: schema_type(klass), optional: false, default: -> { klass.schema }
+          klass.option :context, type: context_type(klass), optional: true, default: -> { klass.context }
+          klass.option :resource, type: resource_type(klass), optional: true,
+            default: -> { Array(klass.resource).first }
+          klass.option :id, type: id_type(klass), optional: true
         end
 
         def run_extensions(klass)
           self.class.extensions.each { |extension| extension.call(klass) }
+        end
+
+        def value_regex(value, klass, default: '[\w\-_]+')
+          return default unless klass.send(value)
+
+          Regexp.escape(klass.send(value))
+        end
+
+        def enum_regex(value, klass, default: '[\w\-_]+')
+          return default unless klass.send(value)
+
+          values = Array(klass.send(value)).map { |v| Regexp.escape(v) }
+          "(#{values.join('|')})"
+        end
+
+        def default_type
+          proc(&:to_s)
+        end
+
+        %i[schema context resource id].each do |attribute|
+          define_method "#{attribute}_type" do |_klass|
+            default_type
+          end
         end
       end
     end

--- a/lib/studitemps/utils/uri/builder.rb
+++ b/lib/studitemps/utils/uri/builder.rb
@@ -15,7 +15,8 @@ module Studitemps
         #
         # @param [String, nil] schema the schema part of the new URI
         # @param [String, nil] context the context part of the new URI
-        # @param [String, nil] resource the resource part of the new URI
+        # @param [String, [String], nil] resource the resource part of the new URI
+        # @param [String, [String], nil] id the optional fixed id part of the new URI
         # @param [String] superclass uri base class
         # @return [Base] the new URI class
         #

--- a/lib/studitemps/utils/uri/extensions/types.rb
+++ b/lib/studitemps/utils/uri/extensions/types.rb
@@ -36,6 +36,21 @@ module Studitemps
         end
       end
 
+      ##
+      # Adds type checks to initializer arguments.
+      # `schema` and `context` values are checked and `resource` and `id` are checked against a possible list of
+      # values (enum if URI builder is provided with an array as the argument).
+      #
+      # @example
+      #   require 'studitemps/utils/uri/extensions/types'
+      #   InvoiceURI = Studitemps::Utils::URI.build(
+      #     schema: 'com.example', context: 'billing', resource: 'invoice', id: %w[final past_due]
+      #   )
+      #
+      #   InvoiceURI.new(id: 'final') # => #<InvoiceURI 'com.example:billing:invoice:final'>
+      #   InvoiceURI.new(id: 'pro_forma') # => Dry::Types::ConstraintError
+      #
+      # @since 0.2.0
       class Builder
         private
 

--- a/lib/studitemps/utils/uri/extensions/types.rb
+++ b/lib/studitemps/utils/uri/extensions/types.rb
@@ -32,6 +32,39 @@ module Studitemps
             types.const_set 'String', Dry.Types.Constructor(klass) { |value| klass.build(value).to_s }
             klass.const_set 'Types', types
           }
+
+        end
+      end
+
+      class Builder
+        private
+
+        def schema_type(klass)
+          value_type(:schema, klass)
+        end
+
+        def context_type(klass)
+          value_type(:context, klass)
+        end
+
+        def resource_type(klass)
+          enum_type(:resource, klass)
+        end
+
+        def id_type(klass)
+          enum_type(:id, klass)
+        end
+
+        def value_type(value, klass, default: default_type)
+          return default unless klass.send(value)
+
+          Dry.Types::Value(klass.send(value))
+        end
+
+        def enum_type(value, klass, default: default_type)
+          return default unless klass.send(value)
+
+          Dry.Types::Strict::String.enum(*Array(klass.send(value)))
         end
       end
     end

--- a/spec/studitemps/uri_spec.rb
+++ b/spec/studitemps/uri_spec.rb
@@ -2,11 +2,6 @@
 
 require 'studitemps/utils/uri'
 
-require 'studitemps/utils/uri/extensions/serialization'
-require 'studitemps/utils/uri/extensions/base64'
-require 'studitemps/utils/uri/extensions/aliases'
-require 'studitemps/utils/uri/extensions/string_equality'
-
 module Studitemps
   module Utils # rubocop:disable Metrics/ModuleLength
     RSpec.describe URI do
@@ -180,10 +175,17 @@ module Studitemps
           end
         end
 
-        context 'features' do
+        # Extensions require special files. Every extesion is loaded in a special `it` test so that we
+        # have not extensions until this point. This requires that we run all tests in order.
+        context 'extensions' do
           context 'de/serialization' do
             subject(:klass) { URI.build(schema: 'com.example', context: 'billing', resource: 'invoice') }
             let(:uri) { klass.new(id: '<id>') }
+
+            it 'can require file' do
+              result = require 'studitemps/utils/uri/extensions/serialization'
+              expect(result).to be true
+            end
 
             specify '.dump' do
               expect(klass.dump(uri)).to eq 'com.example:billing:invoice:<id>'
@@ -201,6 +203,11 @@ module Studitemps
 
             let(:encoded_uri) { 'Y29tLmV4YW1wbGU6YmlsbGluZzppbnZvaWNlOjxpZD4=' }
 
+            it 'can require file' do
+              result = require 'studitemps/utils/uri/extensions/base64'
+              expect(result).to be true
+            end
+
             specify '#base64' do
               expect(uri.to_base64).to eq encoded_uri
             end
@@ -213,6 +220,11 @@ module Studitemps
           context 'aliased methods' do
             subject(:uri) { klass.new(id: '<id>') }
             let(:klass) { URI.build(schema: 'com.example', context: 'billing', resource: 'invoice') }
+
+            it 'can require file' do
+              result = require 'studitemps/utils/uri/extensions/aliases'
+              expect(result).to be true
+            end
 
             specify '#resource_type' do
               expect(uri.resource_type).to eq 'invoice'
@@ -227,15 +239,23 @@ module Studitemps
             subject(:uri) { klass.new(id: '<id>') }
             let(:klass) { URI.build(schema: 'com.example', context: 'billing', resource: 'invoice') }
 
+            it 'can require file' do
+              result = require 'studitemps/utils/uri/extensions/string_equality'
+              expect(result).to be true
+            end
+
             it { is_expected.to eq 'com.example:billing:invoice:<id>' }
             it { is_expected.to eql 'com.example:billing:invoice:<id>' }
           end
 
           context 'types' do
-            require 'studitemps/utils/uri/extensions/types'
-
             let(:uri) { klass.new(id: '<id>') }
             let(:klass) { URI.build(schema: 'com.example', context: 'billing', resource: 'invoice') }
+
+            it 'can require file' do
+              result = require 'studitemps/utils/uri/extensions/types'
+              expect(result).to be true
+            end
 
             describe 'Types Module' do
               let(:uri_type) { klass::Types::URI }

--- a/spec/studitemps/uri_spec.rb
+++ b/spec/studitemps/uri_spec.rb
@@ -6,7 +6,6 @@ require 'studitemps/utils/uri/extensions/serialization'
 require 'studitemps/utils/uri/extensions/base64'
 require 'studitemps/utils/uri/extensions/aliases'
 require 'studitemps/utils/uri/extensions/string_equality'
-require 'studitemps/utils/uri/extensions/types'
 
 module Studitemps
   module Utils # rubocop:disable Metrics/ModuleLength
@@ -39,6 +38,11 @@ module Studitemps
           expect(klass.context).to eq 'billing'
           expect(klass.resource).to eq 'order'
         end
+
+        it 'for a list of IDs' do
+          klass = URI.build(schema: 'com.example', context: 'billing', resource: 'invoice', id: %w[final past_due])
+          expect(klass.id).to eq %w[final past_due]
+        end
       end
 
       describe 'URI regex' do
@@ -55,6 +59,24 @@ module Studitemps
           it { is_expected.to_not match 'com.example:some_context' }
           it { is_expected.to_not match 'com.example:invoice' }
           it { is_expected.to_not match 'com.example:billing:<some_id>' }
+        end
+
+        context 'specific resources' do
+          subject(:regex) {
+            URI.build(schema: 'com.example', context: 'billing', resource: %w[invoice invoice_duplicate])::REGEX
+          }
+
+          it { is_expected.to match 'com.example:billing:invoice:final' }
+          it { is_expected.to_not match 'com.example:billing:bill:final' }
+        end
+
+        context 'specific IDs' do
+          subject(:regex) {
+            URI.build(schema: 'com.example', context: 'billing', resource: 'invoice', id: %w[final past_due])::REGEX
+          }
+
+          it { is_expected.to match 'com.example:billing:invoice:final' }
+          it { is_expected.to_not match 'com.example:billing:invoice:pro_forma' }
         end
       end
 
@@ -210,6 +232,8 @@ module Studitemps
           end
 
           context 'types' do
+            require 'studitemps/utils/uri/extensions/types'
+
             let(:uri) { klass.new(id: '<id>') }
             let(:klass) { URI.build(schema: 'com.example', context: 'billing', resource: 'invoice') }
 
@@ -231,6 +255,48 @@ module Studitemps
                 expect {
                   string_type['something']
                 }.to raise_error ::Studitemps::Utils::URI::Base::InvalidURI
+              end
+            end
+
+            describe 'Attribute Types' do
+              subject(:klass) {
+                URI.build(
+                  schema: 'com.example',
+                  context: 'billing',
+                  resource: resources,
+                  id: ids
+                )
+              }
+              let(:uri) { klass.build('com.example:billing:invoice:final') }
+              let(:ids) { %w[final past_due] }
+              let(:resources) { %w[invoice invoice_duplicate] }
+
+              specify 'schema:' do
+                expect(klass.new(schema: 'com.example', id: 'final')).to eq uri
+                expect {
+                  klass.new(schema: 'com.examplee', id: 'final')
+                }.to raise_error Dry::Types::ConstraintError
+              end
+
+              specify 'context:' do
+                expect(klass.new(context: 'billing', id: 'final')).to eq uri
+                expect {
+                  klass.new(context: 'billingg', id: 'final')
+                }.to raise_error Dry::Types::ConstraintError
+              end
+
+              specify 'resource:' do
+                expect(klass.new(resource: 'invoice', id: 'final')).to eq uri
+                expect {
+                  klass.new(resource: 'bill', id: 'final')
+                }.to raise_error Dry::Types::ConstraintError
+              end
+
+              specify 'id:' do
+                expect(klass.new(id: 'final')).to eq uri
+                expect {
+                  klass.new(id: 'pro_forma')
+                }.to raise_error Dry::Types::ConstraintError
               end
             end
           end


### PR DESCRIPTION
Adds ability to define multiple possible values for `id` and `resource`.

```ruby
MyURI = URI.build(schema: 'com.example', context: 'billing', resource: %w[invoice invoice_duplicate], id: %w[final past_due])
MyURI.build('com.example:billing:invoice:pro_forma') # => InvalidURI

# with types extension

MyURI.new(id: 'pro_forma') # => Dry::Types::ConstraintError

# default is first value

MyURI.new(id: 'final') # => #<MyURI 'com.example:billing:invoice:final'>
``` 